### PR TITLE
Update twitter handle for CODER pool

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1531,7 +1531,7 @@
    "ticker": "CODER",
    "poolId": "b8d2cf0a94b576a06917cef94d0e22b3bcd5d1cda1ba4a11deecfc1f",
    "social": {
-     "twitter": "DanTup",
+     "twitter": "CoderStakePool",
      "facebook": "",
      "reddit": "",	   
      "instagram": "",


### PR DESCRIPTION
I created a seperate Twitter account for the pool to make it easier for delegators to follow updates without my usual spam.

(maybe this info could be scraped from the [extended metadata files](https://a.adapools.org/extended-example) that many pools have?)